### PR TITLE
Fix typo, include_list exclude_list

### DIFF
--- a/macros/assertions_filter.sql
+++ b/macros/assertions_filter.sql
@@ -30,13 +30,13 @@
 
 {%- macro default__assertions_filter(column, exclude_list, include_list, reverse) -%}
 
-{#- Check if both exclude_list and exclude_list are provided -#}
-{%- if exclude_list is not none and exclude_list is not none -%}
+{#- Check if both exclude_list and include_list are provided -#}
+{%- if exclude_list is not none and include_list is not none -%}
     {{
         exceptions.raise_compiler_error(
-            'exclude_list or exclude_list must be provided. Not both.'
+            'exclude_list or include_list must be provided. Not both.'
             ~ 'Got (exclude_list: ' ~ exclude_list 
-            ~ ', exclude_list: ' ~ exclude_list ~ ')'
+            ~ ', include_list: ' ~ include_list ~ ')'
         )
     }}
 {%- endif -%}


### PR DESCRIPTION
Fix small typo when checking if both `include_list` and `exclude_list` are provided