### PR TITLE
Feat/snowflake support and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ packages:
 |**Database**|[assertions](#assertions)|[assertions_filter](#assertions_filter)|[\_\_unique__](#__unique__-helper)|[\_\_not_null__](#__not_null__-helper)|[generic_assertions](#generic_assertions)
 |:---:|:---:|:---:|:---:|:---:|:---:|
 |BigQuery (default)|✅|✅|✅|✅|✅|
-|Snowflake|✅ </br> (alpha)|✅ </br> (alpha)|❌|❌|✔️|
+|Snowflake|✅ </br> (alpha)|✅ </br> (alpha)|✅ </br> (alpha, not nested fields)|✅ </br> (alpha, not nested fields)|✅ </br> (alpha)|
 |Others|ℹ️|ℹ️|ℹ️|ℹ️|ℹ️|
 
 - ✅: supported

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ WHERE {{ dbt_assertions.assertions_filter(exclude_list=['assertions_id']) }}
 
 ####  [generic_assertions](tests/generic/generic_assertions.sql)
 
-Generates a test to get rows based on exceptionss.
+Generates a test to get rows based on exceptions.
 
 It will returns the rows without any exception by default.
 You can change this default behaviour specifying a exclude_list or include_list (not both).
@@ -294,7 +294,7 @@ Custom assertions are the basics assertions.
 It is represented as key values. Keys are the ID of the assertions.
 
 Each assertions is defined by at least an `expression` which will be rendered
-to be evaulated as your test.
+to be evaluated as your test.
 
 `description` and [`null_as_exception`](#null_as_exception) are optional.
 
@@ -371,7 +371,7 @@ assertions:
 ---
 
 You can also verify unique keys for nested/repeated structure. It will generate:
-- One assertion for the 0-depth guaranteeing uniqueness **accross the rows**.
+- One assertion for the 0-depth guaranteeing uniqueness **across the rows**.
 - One assertion **for each** repeated field guaranteeing uniqueness **within the row**.
 
 
@@ -495,7 +495,7 @@ WITH final AS
 SELECT
     *,
     {{ dbt_assertions.assertions(column='errors') }},
-    {{ dbt_assertions.assertions(column='warns') }},
+    {{ dbt_assertions.assertions(column='warns') }}
 FROM {{ ref('my_model') }}
 ```
 

--- a/tests/generic/generic_assertions.sql
+++ b/tests/generic/generic_assertions.sql
@@ -17,7 +17,7 @@
 -#}
 
 WITH
-    final AS (
+    dbt_assertions_final AS (
         SELECT
             *
             {%- if re_assert and execute %}
@@ -45,7 +45,7 @@ WITH
 
 SELECT
     *
-FROM `final`
+FROM dbt_assertions_final
 WHERE {{ dbt_assertions.assertions_filter(column, exclude_list, include_list, reverse=true) }}
 
 {% endtest %}


### PR DESCRIPTION
I tested the rest of the features on Snowflake this morning

- a small change was required to make `generic_assertions` work (`` ` `` is not a valid object quoting char in Snowflake)
- `__not_null__` and `__unique__` actually work without any change required, as long as we only use top level fields
  - by personal experience, objects/strucs are less used in Snowflake than in BigQuery so I wouldn't expect most people to want to use nested fields on Snowflake

I also updated the README with the latest info.

Is there anything that you would like me to add be fore making a "non alpha" release with support for Snowflake. I am happy to continue helping here.