### PR TITLE
Feature/add athena assertion macros

### DIFF
--- a/macros/_assertions_expression.sql
+++ b/macros/_assertions_expression.sql
@@ -147,7 +147,6 @@ ARRAY_FLATTEN(
 
 {%- macro athena___assertions_expression(column, assertions) -%}
 
-ARRAY_JOIN(
     ARRAY[
         {%- for assertion_id, assertion_config in assertions.items() %}
         {%- set expression =
@@ -168,9 +167,8 @@ ARRAY_JOIN(
         ),
         {%- endfor %}
         NULL
-    ],
-    ','
-) AS {{ column }}
+    ]
+ AS {{ column }}
 
 {%- endmacro %}
  

--- a/macros/assertions_filter.sql
+++ b/macros/assertions_filter.sql
@@ -164,3 +164,22 @@ SIZE({{ column }}) = 0
 GET_ARRAY_LENGTH({{ column }}) = 0
 
 {%- endmacro %}
+
+{%- macro athena__assertions_filter(column, exclude_list, include_list, reverse) -%}
+
+{#- Check if both exclude_list and include_list are provided -#}
+{%- if exclude_list is not none and include_list is not none -%}
+    {{
+        exceptions.warn(
+            'exclude_list and include_list is not supported for Athena.'
+            ~ 'Got (exclude_list: ' ~ exclude_list
+            ~ ', include_list: ' ~ include_list ~ ')'
+        )
+    }}
+{%- endif -%}
+
+{#- Generate filtering expression  -#}
+{{- 'NOT ' if reverse else '' -}}
+CARDINALITY({{ column }}) = 0
+
+{%- endmacro %}


### PR DESCRIPTION
I have added the macros for Athena. 

The results of the integration tests are as follows:

`pwd 
/Users/vaisakh.mohan/Documents/public_packages/dbt-assertions/integration_tests
vaisakh.mohan@M77722001ABC integration_tests % dbt build
11:01:53  Running with dbt=1.8.7
11:01:54  Registered adapter: athena=1.8.1
11:01:54  Found 4 models, 1 test, 471 macros
11:01:54  
11:01:56  Concurrency: 1 threads (target='dev')
11:01:56  
11:01:56  1 of 5 START sql view model exmaple_com_cge_transformed_staging_euc1_bd.basic_example_d_site  [RUN]
11:01:59  1 of 5 OK created sql view model exmaple_com_cge_transformed_staging_euc1_bd.basic_example_d_site  [OK -1 in 2.95s]
11:01:59  2 of 5 START sql view model exmaple_com_cge_transformed_staging_euc1_bd.basic_test_example_d_site  [RUN]
11:02:02  2 of 5 OK created sql view model exmaple_com_cge_transformed_staging_euc1_bd.basic_test_example_d_site  [OK -1 in 2.78s]
11:02:02  3 of 5 START sql view model exmaple_com_cge_transformed_staging_euc1_bd.two_assertions_columns_d_site  [RUN]
11:02:05  3 of 5 OK created sql view model exmaple_com_cge_transformed_staging_euc1_bd.two_assertions_columns_d_site  [OK -1 in 2.71s]
11:02:05  4 of 5 START sql table model exmaple_com_cge_transformed_staging_euc1_bd.downstream_model  [RUN]
11:02:14  4 of 5 OK created sql table model exmaple_com_cge_transformed_staging_euc1_bd.downstream_model  [OK 2 in 9.04s]
11:02:14  5 of 5 START test dbt_assertions_generic_assertions_basic_test_example_d_site_exceptions__site_id_is_not_null__True  [RUN]
11:02:15  5 of 5 PASS dbt_assertions_generic_assertions_basic_test_example_d_site_exceptions__site_id_is_not_null__True  [PASS in 1.83s]
11:02:15  
11:02:15  Finished running 3 view models, 1 table model, 1 test in 0 hours 0 minutes and 21.53 seconds (21.53s).
11:02:16  
11:02:16  Completed successfully
11:02:16  
11:02:16  Done. PASS=5 WARN=0 ERROR=0 SKIP=0 TOTAL=5`