### PR TITLE
Added null filter for athena__assertions_filter

### DIFF
--- a/macros/assertions_filter.sql
+++ b/macros/assertions_filter.sql
@@ -181,11 +181,11 @@ GET_ARRAY_LENGTH({{ column }}) = 0
 {#- Generate filtering expression  -#}
 {{- 'NOT ' if reverse else '' -}}
 {%- if include_list is not none -%}
-CARDINALITY(ARRAY_INTERSECT({{ column }}, ARRAY['{{ include_list | join("\', \'")}}'])) = 0
+CARDINALITY(filter(ARRAY_INTERSECT({{ column }}, ARRAY['{{ include_list | join("\', \'")}}']),  x -> x IS NOT NULL)) = 0
 {%- elif exclude_list is not none -%}
-CARDINALITY(ARRAY_EXCEPT({{ column }}, ARRAY['{{ exclude_list | join("\', \'")}}'])) = 0
+CARDINALITY(filter(ARRAY_EXCEPT({{ column }}, ARRAY['{{ exclude_list | join("\', \'")}}']),  x -> x IS NOT NULL)) = 0
 {%- else -%}
-CARDINALITY({{ column }}) = 0
+CARDINALITY(filter({{ column }}, x -> x IS NOT NULL)) = 0
 {%- endif -%}
 
 {%- endmacro %}


### PR DESCRIPTION
The previous implementation was also counting nulls in cardinality. This is not desirable while applying filters. The new filter additions will not require nulls to be handled separtely.

19:13:00  1 of 5 START sql view model exmaple_com_cge_transformed_rejected_euc1_bd.basic_example_d_site  [RUN]
19:13:03  1 of 5 OK created sql view model exmaple_com_cge_transformed_rejected_euc1_bd.basic_example_d_site  [OK -1 in 2.78s]
19:13:03  2 of 5 START sql view model exmaple_com_cge_transformed_rejected_euc1_bd.basic_test_example_d_site  [RUN]
19:13:05  2 of 5 OK created sql view model exmaple_com_cge_transformed_rejected_euc1_bd.basic_test_example_d_site  [OK -1 in 2.42s]
19:13:05  3 of 5 START sql view model exmaple_com_cge_transformed_rejected_euc1_bd.two_assertions_columns_d_site  [RUN]
19:13:07  3 of 5 OK created sql view model exmaple_com_cge_transformed_rejected_euc1_bd.two_assertions_columns_d_site  [OK -1 in 2.38s]
19:13:07  4 of 5 START sql table model exmaple_com_cge_transformed_rejected_euc1_bd.downstream_model  [RUN]
19:13:13  4 of 5 OK created sql table model exmaple_com_cge_transformed_rejected_euc1_bd.downstream_model  [OK 2 in 6.14s]
19:13:13  5 of 5 START test dbt_assertions_generic_assertions_basic_test_example_d_site_exceptions__site_id_is_not_null__True  [RUN]
19:13:15  5 of 5 PASS dbt_assertions_generic_assertions_basic_test_example_d_site_exceptions__site_id_is_not_null__True  [PASS in 1.72s]